### PR TITLE
Add ObjDetect message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ project(hieroglyph)
 
 set(CATKIN_DEP
   std_msgs
+  sensor_msgs
   message_generation
   genmsg
 )
@@ -39,6 +40,7 @@ add_message_files(
    OscilloArray.msg
    JointPos.msg
    JointVel.msg
+   ObjDetect.msg
 )
 
 ## Generate services in the 'srv' folder
@@ -63,6 +65,7 @@ add_service_files(
 generate_messages(
    DEPENDENCIES
    std_msgs
+   sensor_msgs
 )
 
 ################################################

--- a/msg/ObjDetect.msg
+++ b/msg/ObjDetect.msg
@@ -1,0 +1,2 @@
+sensor_msgs/PointCloud2 position
+float64[] confidence

--- a/package.xml
+++ b/package.xml
@@ -18,4 +18,5 @@
   <depend>message_generation</depend>
   <depend>genmsg</depend>
   <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
 </package>


### PR DESCRIPTION
Add message ObjDetect, which is used to communicate between object detection programs and kheops. This message contains a point cloud ROS message "sensor_msgs/PointCloud2" filled with the detected objects position and a list of float values corresponding to the confidence of each detected objects.
The Function ObjDetectSub in alexandria can read this message.